### PR TITLE
Fix: Remove redundant camera_metadata_headers dependency

### DIFF
--- a/app/Android.bp
+++ b/app/Android.bp
@@ -87,7 +87,6 @@ cc_library_shared {
     header_libs: [
         "libhardware_headers", 
         "libnativehelper_header_only", 
-        "camera_metadata_headers",
         // Headers for AHardwareBuffer are part of NDK, usually implicitly available
         // "libandroid_headers", // Could be a source for some platform headers if needed
     ],


### PR DESCRIPTION
The libcamera_metadata dependency already provides the necessary headers for libcambridge_jni. This change removes the redundant header_libs entry for camera_metadata_headers, which was causing a build failure due to the module not being found.