### PR TITLE
Fix: Resolve JNI header dependency issues

### DIFF
--- a/app/Android.bp
+++ b/app/Android.bp
@@ -87,8 +87,13 @@ cc_library_shared {
     header_libs: [
         "libhardware_headers", 
         "libnativehelper_header_only", 
+        // "camera_metadata_headers", // Removed, assuming libcamera_metadata provides them
         // Headers for AHardwareBuffer are part of NDK, usually implicitly available
         // "libandroid_headers", // Could be a source for some platform headers if needed
+        "android.hardware.camera.common-V1-ndk",
+        "android.hardware.camera.provider-V1-ndk",
+        "android.hardware.camera.device-V1-ndk",
+        "android.hardware.graphics.common-V3-ndk",
     ],
     export_include_dirs: ["src/main/cpp"], // So other modules can include HAL headers
 }


### PR DESCRIPTION
- Removed `camera_metadata_headers` from `header_libs` for `libcambridge_jni` as `libcamera_metadata` is expected to provide these headers.
- Added AIDL NDK camera libraries to `header_libs` to ensure their headers, particularly `HalStreamConfiguration.h`, are correctly found during compilation.

These changes address build failures related to missing header dependencies for `libcambridge_jni`.